### PR TITLE
change version restriction on FSharp.Core so that usage FSharp.Core 5…

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -10,7 +10,7 @@ group UseListener
     nuget Fable.Browser.Dom >= 2.1
     nuget Fable.Core ~> 3
     nuget Feliz ~> 1
-    nuget FSharp.Core ~> 4.7
+    nuget FSharp.Core >= 4.7
 
 group Docs
     source https://nuget.org/api/v2


### PR DESCRIPTION
….0 is possible

<!-- Please refer to our contributing documentation for any questions on submitting a pull request. -->
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`fake build` or `.\build.cmd`) on local branch was successful

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): Update of  bounds for version requirements for FSharp.Core

## What is the current behavior?
Currently FSharp.Core 5.0 is not supported

## What is the new behavior?
FSharp.Core is supported

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
