### PR TITLE
Lift Restriction on Fable and Feliz version

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -7,8 +7,8 @@ group UseListener
 	source https://api.nuget.org/v3/index.json
 
     nuget Fable.Browser.Dom >= 2.1
-    nuget Fable.Core ~> 3
-    nuget Feliz ~> 1
+    nuget Fable.Core >= 3
+    nuget Feliz >= 2
     nuget FSharp.Core >= 4.7.2 lowest_matching: true
 
 group Docs

--- a/paket.lock
+++ b/paket.lock
@@ -754,35 +754,40 @@ NUGET
 GROUP UseListener
 NUGET
   remote: https://www.nuget.org/api/v2
-    Fable.AST (3.0.0-nagareyama-beta-002) - restriction: >= netstandard2.0
-    Fable.Browser.Blob (1.1) - restriction: >= netstandard2.0
+    Fable.AST (4.2.1) - restriction: >= netstandard2.0
+    Fable.Browser.Blob (1.3) - restriction: >= netstandard2.0
       Fable.Core (>= 3.0) - restriction: >= netstandard2.0
-      FSharp.Core (>= 4.6.2) - restriction: >= netstandard2.0
-    Fable.Browser.Dom (2.1.2)
-      Fable.Browser.Blob (>= 1.1) - restriction: >= netstandard2.0
-      Fable.Browser.Event (>= 1.2.1) - restriction: >= netstandard2.0
-      Fable.Browser.WebStorage (>= 1.0) - restriction: >= netstandard2.0
-      Fable.Core (>= 3.0) - restriction: >= netstandard2.0
-      FSharp.Core (>= 4.7.1) - restriction: >= netstandard2.0
-    Fable.Browser.Event (1.2.1) - restriction: >= netstandard2.0
-      Fable.Core (>= 3.0) - restriction: >= netstandard2.0
-      FSharp.Core (>= 4.7) - restriction: >= netstandard2.0
-    Fable.Browser.WebStorage (1.0) - restriction: >= netstandard2.0
-      Fable.Browser.Event (>= 1.0) - restriction: >= netstandard2.0
-      Fable.Core (>= 3.0) - restriction: >= netstandard2.0
-      FSharp.Core (>= 4.5.2) - restriction: >= netstandard2.0
-    Fable.Core (3.1.6)
-      FSharp.Core (>= 4.7.1) - restriction: >= netstandard2.0
-    Fable.React (7.0.1) - restriction: >= netstandard2.0
-      Fable.Browser.Dom (>= 2.0.1) - restriction: >= netstandard2.0
-      Fable.Core (>= 3.1.5) - restriction: >= netstandard2.0
-      FSharp.Core (>= 4.7.1) - restriction: >= netstandard2.0
-    Feliz (1.17)
-      Fable.Core (>= 3.1.5) - restriction: >= netstandard2.0
-      Fable.React (>= 7.0.1) - restriction: >= netstandard2.0
-      Feliz.CompilerPlugins (>= 0.4) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
-    Feliz.CompilerPlugins (0.4) - restriction: >= netstandard2.0
-      Fable.AST (>= 3.0.0-nagareyama-beta-002) - restriction: >= netstandard2.0
-      FSharp.Core (>= 4.7.1) - restriction: >= netstandard2.0
+    Fable.Browser.Dom (2.14)
+      Fable.Browser.Blob (>= 1.3) - restriction: >= netstandard2.0
+      Fable.Browser.Event (>= 1.5) - restriction: >= netstandard2.0
+      Fable.Browser.WebStorage (>= 1.2) - restriction: >= netstandard2.0
+      Fable.Core (>= 3.2.8) - restriction: >= netstandard2.0
+      FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
+    Fable.Browser.Event (1.5) - restriction: >= netstandard2.0
+      Fable.Browser.Gamepad (>= 1.1) - restriction: >= netstandard2.0
+      Fable.Core (>= 3.0) - restriction: >= netstandard2.0
+      FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
+    Fable.Browser.Gamepad (1.2) - restriction: >= netstandard2.0
+      Fable.Core (>= 3.0) - restriction: >= netstandard2.0
+      FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
+    Fable.Browser.WebStorage (1.2) - restriction: >= netstandard2.0
+      Fable.Browser.Event (>= 1.5) - restriction: >= netstandard2.0
+      Fable.Core (>= 3.0) - restriction: >= netstandard2.0
+      FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
+    Fable.Core (3.7.1) - restriction: >= netstandard2.0
+    Fable.React.Types (18.3) - restriction: >= netstandard2.0
+      Fable.Browser.Dom (>= 2.4.4) - restriction: >= netstandard2.0
+      Fable.Core (>= 3.2.7) - restriction: >= netstandard2.0
+      FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
+    Fable.ReactDom.Types (18.2) - restriction: >= netstandard2.0
+      Fable.React.Types (>= 18.3) - restriction: >= netstandard2.0
+      FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
+    Feliz (2.4)
+      Fable.ReactDom.Types (>= 18.2) - restriction: >= netstandard2.0
+      Feliz.CompilerPlugins (>= 2.0) - restriction: >= netstandard2.0
+      FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
+    Feliz.CompilerPlugins (2.0) - restriction: >= netstandard2.0
+      Fable.AST (>= 4.2.1) - restriction: >= netstandard2.0
+      FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
     FSharp.Core (4.7.2)


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request. -->
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`fake build` or `.\build.cmd`) on local branch was successful
  - For some reason the build wants to use Mono on my local machine, which makes it fail. Not so sure why this happens.

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
There's an upper restriction on the Feliz and Fable version:
![image](https://user-images.githubusercontent.com/16801528/217025102-c995e7da-523e-449f-8611-a39e833e1dec.png)

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
This PR removes this upper restriction. Currently no changes are needed to make it possible to use this library with React 18 aswell.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
